### PR TITLE
Tag 1.4.0 as compatible

### DIFF
--- a/code/extensions/chip/config.xml
+++ b/code/extensions/chip/config.xml
@@ -7,6 +7,7 @@
     <item>1.1</item>
     <item>1.2</item>
     <item>1.3</item>
+    <item>1.4</item>
   </cartversions>
   <phpmodules>
     <item>curl</item>

--- a/code/extensions/chip/config.xml
+++ b/code/extensions/chip/config.xml
@@ -2,11 +2,8 @@
 <!-- https://abantecart.atlassian.net/wiki/spaces/DOC/pages/17956965/Extension+configuration+file -->
 <extension>
   <id>chip</id>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <cartversions>
-    <item>1.1</item>
-    <item>1.2</item>
-    <item>1.3</item>
     <item>1.4</item>
   </cartversions>
   <phpmodules>

--- a/code/extensions/chip/storefront/controller/responses/extension/chip.php
+++ b/code/extensions/chip/storefront/controller/responses/extension/chip.php
@@ -218,7 +218,7 @@ class ControllerResponsesExtensionChip extends AController
     }
 
     if ($order_info['order_status_id'] == $success_id) {
-      redirect($this->html->getSecureURL('checkout/success'));
+      redirect($this->html->getSecureURL('checkout/finalize'));
     }
 
     $payment_method_data = unserialize( $order_info['payment_method_data'] );
@@ -237,10 +237,11 @@ class ControllerResponsesExtensionChip extends AController
 
       $this->model_extension_chip->release_lock($order_id);
 
-      redirect($this->html->getSecureURL('checkout/success'));
+      redirect($this->html->getSecureURL('checkout/finalize'));
     }
 
-    redirect($this->html->getSecureURL('checkout/cart', '&mode=edit', true));
+    $pKey = $this->session->data['fc']['product_key'];
+    redirect($this->html->getSecureURL('checkout/fast_checkout', $pKey ? '&fc=1&product_key='.$pKey : ''));
   }
 
   public function callback_url() {

--- a/code/extensions/chip/storefront/view/default/template/responses/chip.tpl
+++ b/code/extensions/chip/storefront/view/default/template/responses/chip.tpl
@@ -1,4 +1,4 @@
-<form action="<?php echo $this->html->getURL('extension/chip/confirm');?>" method="get">
+<form id="CHIPFrm" action="<?php echo $this->html->getURL('extension/chip/confirm');?>" method="get">
     <div class="form-group action-buttons">
         <div class="col-md-12">
             <a id="checkout_btn" onclick="confirmCHIP(event);" class="btn btn-orange pull-right lock-on-click" title="<?php echo $button_confirm->text ?>">

--- a/code/extensions/chip/storefront/view/novator/template/responses/chip.tpl
+++ b/code/extensions/chip/storefront/view/novator/template/responses/chip.tpl
@@ -1,8 +1,8 @@
 <form id="CHIPFrm" action="<?php echo $this->html->getURL('extension/chip/confirm');?>" method="get">
     <div class="form-group action-buttons">
         <div class="col-md-12">
-            <button type="submit" id="checkout_btn" class="btn btn-primary" title="<?php echo $button_confirm->text ?>">
-                <i class="fa fa-check"></i>
+            <button type="submit" id="checkout_btn" class="btn btn-primary fs-5 fw-bold" title="<?php echo $button_confirm->text ?>">
+                <i class="bi bi-check-lg"></i>
                 <?php echo $button_confirm->text; ?>
             </button>
         </div>

--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,7 @@
 		<item>1.1</item>
 		<item>1.2</item>
 		<item>1.3</item>
+		<item>1.4</item>
 	</cartversions>
 	<package_content>
 		<extensions>

--- a/package.xml
+++ b/package.xml
@@ -2,11 +2,8 @@
 <package>
     <id>chip</id>
     <type>extension</type>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<cartversions>		
-		<item>1.1</item>
-		<item>1.2</item>
-		<item>1.3</item>
 		<item>1.4</item>
 	</cartversions>
 	<package_content>


### PR DESCRIPTION
## What does this change?
- Tag AbanteCart version 1.4.0 as compatible.
- Default to `novator` template
- Using fast_checkout since integrated into core.

## Asana / Jira / Trello task link
[Asana](https://app.asana.com/0/1203417845528369/1208634484067703/f)

## How to test
Install with AbanteCart 1.4.0

## Images

## PR Checklist:

-   [ ] Unit test provided?
-   [ ] All unit tests passed?
-   [ ] Deployed and tested in staging?
-   [ ] Project Management Solution (Asana / Jira / Trello) task link provided?
